### PR TITLE
Feature/save and view posters

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,5 @@
+//If a user clicks the “Save This Poster” more than once on a single poster, it will still only be saved once (no duplicates)
+
 // query selector variables go here 👇
 var posterImg = document.querySelector(".poster-img");
 var posterTitle = document.querySelector(".poster-title");
@@ -14,6 +16,7 @@ var showMyPosterBtn = document.querySelector('.make-poster');
 var userImageURL = document.getElementById('poster-image-url');
 var userTitle = document.getElementById('poster-title');
 var userQuote = document.getElementById('poster-quote');
+var savePosterBtn = document.querySelector('.save-poster');
 
 // we've provided you with some data to work with 👇
 var images = [
@@ -123,7 +126,8 @@ makeYourOwnBtn.addEventListener("click", showForm);
 showSavedBtn.addEventListener("click", showSaved)
 takeMeBackBtn.addEventListener("click", showMain);
 backToMainBtn.addEventListener("click", showMain);
-showMyPosterBtn.addEventListener("click", showUserPoster)
+showMyPosterBtn.addEventListener("click", showUserPoster);
+savePosterBtn.addEventListener("click", addToSavedPosters);
 
 // functions and event handlers go here 👇
 function loadHomePage() {
@@ -137,6 +141,12 @@ function createRandomPoster() {
   var fetchQuote = quotes[getRandomIndex(quotes)];
 
   currentPoster = new Poster(fetchImage, fetchTitle, fetchQuote);
+}
+
+function showPoster() {
+  posterImg.src = currentPoster.imageURL;
+  posterTitle.innerText = currentPoster.title;
+  posterQuote.innerText = currentPoster.quote;
 }
 
 function showForm() {
@@ -171,12 +181,9 @@ function showUserPoster(event) {
   showPoster();
 }
 
-function showPoster() {
-  posterImg.src = currentPoster.imageURL;
-  posterTitle.innerText = currentPoster.title;
-  posterQuote.innerText = currentPoster.quote;
+function addToSavedPosters() {
+  savedPosters.push(currentPoster);
 }
-
 
 // (we've provided one for you to get you started)!
 function getRandomIndex(array) {

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,3 @@
-//If a user clicks the “Save This Poster” more than once on a single poster, it will still only be saved once (no duplicates)
-
 // query selector variables go here 👇
 var posterImg = document.querySelector(".poster-img");
 var posterTitle = document.querySelector(".poster-title");
@@ -17,6 +15,7 @@ var userImageURL = document.getElementById('poster-image-url');
 var userTitle = document.getElementById('poster-title');
 var userQuote = document.getElementById('poster-quote');
 var savePosterBtn = document.querySelector('.save-poster');
+var savedPostersGrid = document.querySelector('.saved-posters-grid');
 
 // we've provided you with some data to work with 👇
 var images = [
@@ -182,11 +181,19 @@ function showUserPoster(event) {
 }
 
 function addToSavedPosters() {
-  savedPosters.push(currentPoster);
+  if (!savedPosters.includes(currentPoster)) {
+    savedPosters.push(currentPoster);
+
+    savedPostersGrid.innerHTML += 
+    `<section class="mini-poster">
+      <img class="poster-img" src="${currentPoster.imageURL}">
+      <h2 class="poster-title">${currentPoster.title}</h2>
+      <h4 class="poster-quote">${currentPoster.quote}</h4>
+    </section>`
+  } 
 }
 
 // (we've provided one for you to get you started)!
 function getRandomIndex(array) {
   return Math.floor(Math.random() * array.length);
 }
-


### PR DESCRIPTION
We added an event listener to "Save Poster" button which pushes the current poster instance to the saved posters array, as well as creating an inner HTML to the saved posters grid. The inner HTML contains a section with a class of "mini-poster" so that users can see the appropriate styling for the mini posters (in the saved posters section). Additionally, we added a conditional so that users cannot save the same poster twice (prevent duplicates). 